### PR TITLE
Hent tiltaktype fra komet

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometResponse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometResponse.kt
@@ -24,6 +24,7 @@ data class GjennomforingDTO(
     val id: String,
     val navn: String,
     val type: String, // Arena type
+    val tiltakstypeNavn: String,
     val arrangor: ArrangorDTO,
 )
 

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
@@ -24,7 +24,6 @@ import no.nav.tiltakspenger.tiltak.clients.komet.DeltakerStatusDTO.VURDERES
 import no.nav.tiltakspenger.tiltak.clients.komet.KometClient
 import no.nav.tiltakspenger.tiltak.clients.tiltak.TiltakClient
 import no.nav.tiltakspenger.tiltak.clients.valp.ValpClient
-import no.nav.tiltakspenger.tiltak.clients.valp.ValpDTO
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -41,10 +40,8 @@ class RouteServiceImpl(
             val kometOgValp = kometClient.hentTiltakDeltagelser(fnr)
                 .also { securelog.info { "Hele svaret fra komet $it" } }
                 .map { deltakelse ->
-                    val gjennomføring = valpClient.hentTiltakGjennomføring(deltakelse.gjennomforing.id)
-                        ?: throw IllegalStateException("Fant ikke gjennomføring i Valp")
                     securelog.info { "Deltakelsene vi mapper tilbake $deltakelse" }
-                    mapKometTiltak(deltakelse, gjennomføring)
+                    mapKometTiltak(deltakelse)
                 }
 
             val arena = arenaClient.hentTiltakArena(fnr)
@@ -68,7 +65,7 @@ class RouteServiceImpl(
     }
 }
 
-private fun mapKometTiltak(deltakelse: DeltakerDTO, gjennomføring: ValpDTO): TiltakDTO {
+private fun mapKometTiltak(deltakelse: DeltakerDTO): TiltakDTO {
     return TiltakDTO(
         id = deltakelse.id,
         deltakelseFom = deltakelse.startDato,
@@ -79,10 +76,10 @@ private fun mapKometTiltak(deltakelse: DeltakerDTO, gjennomføring: ValpDTO): Ti
         gjennomforing = TiltakResponsDTO.GjennomføringDTO(
             id = deltakelse.gjennomforing.id,
             arrangørnavn = deltakelse.gjennomforing.arrangor.navn,
-            typeNavn = gjennomføring.tiltakstype.navn,
-            arenaKode = TiltakType.valueOf(gjennomføring.tiltakstype.arenaKode),
-            fom = gjennomføring.startDato,
-            tom = gjennomføring.sluttDato,
+            typeNavn = deltakelse.gjennomforing.tiltakstypeNavn,
+            arenaKode = TiltakType.valueOf(deltakelse.gjennomforing.type),
+            fom = null,
+            tom = null,
         ),
         kilde = "Komet",
         deltakelseStatus = when (deltakelse.status) {

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
@@ -37,22 +37,19 @@ class RouteServiceImpl(
 ) : RoutesService {
     override fun hentAlleTiltak(fnr: String): List<TiltakDTO> {
         val tiltakdeltakelser = runBlocking {
-            val kometOgValp = kometClient.hentTiltakDeltagelser(fnr)
-                .also { securelog.info { "Hele svaret fra komet $it" } }
+            val komet = kometClient.hentTiltakDeltagelser(fnr)
                 .map { deltakelse ->
-                    securelog.info { "Deltakelsene vi mapper tilbake $deltakelse" }
                     mapKometTiltak(deltakelse)
                 }
 
             val arena = arenaClient.hentTiltakArena(fnr)
-                .also { securelog.info { "Hele svaret fra arena $it" } }
                 .filterNot { it.tiltakType.name in tiltakViFårFraKomet }
                 .map {
                     securelog.info { "Deltakelsene fra Arena vi mapper tilbake $it" }
                     mapArenaTiltak(it)
                 }
 
-            arena + kometOgValp
+            arena + komet
         }
 
         return tiltakdeltakelser

--- a/src/test/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometClientImplTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometClientImplTest.kt
@@ -53,6 +53,7 @@ internal class KometClientImplTest {
                         id = "bc4a05a5-56ed-47ac-8176-b685b0731751",
                         navn = "Testing Linn 1",
                         type = "INDOPPFAG",
+                        tiltakstypeNavn = "Oppfølging",
                         arrangor = ArrangorDTO(
                             virksomhetsnummer = "974548283",
                             navn = "TINN KOMMUNE KOMMUNEDIREKTØRENS STAB",
@@ -70,6 +71,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "bc4a05a5-56ed-47ac-8176-b685b0731751",
               "navn": "Testing Linn 1",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "974548283",
@@ -88,6 +90,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "e0036a1f-ba82-4a45-95d0-8d5008d8881c",
               "navn": "Astronomisk testtiltak - oppfølging",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "974750449",
@@ -106,6 +109,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "e700a519-b41a-4407-9dac-6d2375cd4c50",
               "navn": "oppfølgingstiltak linn,alex,lars",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "974750449",
@@ -124,6 +128,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "c0656b88-39a6-4d96-b3e0-6271ecb48698",
               "navn": "testtiltak oppfølging 20.01.2022",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "974750449",
@@ -142,6 +147,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "eae379be-306b-4f09-b473-f01483975eb4",
               "navn": "Izis testgjennomføring",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "974750449",
@@ -160,6 +166,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "c4212ab6-1b48-4ff7-bb4f-bbc086e6a2d2",
               "navn": "Avklaring teste at ikke dukker opp hos Komet",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "AVKLARAG",
               "arrangor": {
                 "virksomhetsnummer": "974750449",
@@ -178,6 +185,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "f34644e1-3216-4251-85fc-6114ff0ab420",
               "navn": "test AFT Tinn bhg - Lars",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "ARBFORB",
               "arrangor": {
                 "virksomhetsnummer": "914016444",
@@ -196,6 +204,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "c3e72527-5447-48f1-b51d-2ddea382850e",
               "navn": "oppfølging Tinn avd. 1 - Lars",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "974548283",
@@ -214,6 +223,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "8c42c8cd-f832-41fe-b2a7-67eda83c1705",
               "navn": "ARR - Tinn harnehage - Lars",
+              "tiltakstypeNavn": "Arbeidsrettet rehabilitering (dag)",
               "type": "ARBRRHDAG",
               "arrangor": {
                 "virksomhetsnummer": "914016444",
@@ -232,6 +242,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "ed7a3161-495c-4409-b08e-128a6f0d03ce",
               "navn": "Oppfølging Tinn bhg - test Lars",
+              "tiltakstypeNavn": "Oppfølging",
               "type": "INDOPPFAG",
               "arrangor": {
                 "virksomhetsnummer": "914016444",
@@ -250,6 +261,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "a972d2c1-7fb4-4207-af5d-4fea5561ea60",
               "navn": "Modist vg 2 - Lars fra Mars",
+              "tiltakstypeNavn": "Gruppe AMO",
               "type": "GRUPPEAMO",
               "arrangor": {
                 "virksomhetsnummer": "974548283",
@@ -268,6 +280,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "cff08d1e-62f7-4f85-9faf-aef8e21c4021",
               "navn": "Fagkurs - Astronomisk hattemakeri",
+              "tiltakstypeNavn": "Gruppe Fag- og yrkesopplæring VGS og høyere yrkesfaglig utdanning",
               "type": "GRUFAGYRKE",
               "arrangor": {
                 "virksomhetsnummer": "974750449",
@@ -286,6 +299,7 @@ internal class KometClientImplTest {
             "gjennomforing": {
               "id": "825ed2fa-6506-4fe1-a6c1-2120cf6c9abb",
               "navn": "Lars - gruppe-AMO test",
+              "tiltakstypeNavn": "Gruppe AMO",
               "type": "GRUPPEAMO",
               "arrangor": {
                 "virksomhetsnummer": "974548283",

--- a/src/test/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImplTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImplTest.kt
@@ -19,11 +19,7 @@ import no.nav.tiltakspenger.tiltak.clients.komet.DeltakerStatusDTO
 import no.nav.tiltakspenger.tiltak.clients.komet.GjennomforingDTO
 import no.nav.tiltakspenger.tiltak.clients.komet.KometClient
 import no.nav.tiltakspenger.tiltak.clients.tiltak.TiltakClient
-import no.nav.tiltakspenger.tiltak.clients.valp.TiltaksgjennomforingOppstartstype
-import no.nav.tiltakspenger.tiltak.clients.valp.Tiltaksgjennomforingsstatus
-import no.nav.tiltakspenger.tiltak.clients.valp.Tiltakstype
 import no.nav.tiltakspenger.tiltak.clients.valp.ValpClient
-import no.nav.tiltakspenger.tiltak.clients.valp.ValpDTO
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -47,7 +43,6 @@ internal class RouteServiceImplTest {
         coEvery { kometClient.hentTiltakDeltagelser(any()) } returns listOf(
             kometDeltaker("VASV", DeltakerStatusDTO.AVBRUTT),
         )
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("VASV")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             arenaTiltak(KURS, DeltakerStatusType.DELAVB),
         )
@@ -81,7 +76,6 @@ internal class RouteServiceImplTest {
             kometDeltaker("ARBFORB", DeltakerStatusDTO.SOKT_INN),
             kometDeltaker("ARBFORB", DeltakerStatusDTO.VENTELISTE),
         )
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("ARBFORB")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             // Disse skal være med
             arenaTiltak(AMO, DeltakerStatusType.DELAVB),
@@ -128,7 +122,6 @@ internal class RouteServiceImplTest {
         )
 
         coEvery { kometClient.hentTiltakDeltagelser(any()) } returns emptyList()
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("ARBFORB")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             arenaTiltak(tiltak = AMO, status = DeltakerStatusType.GJENN, LocalDate.now().plusDays(10), LocalDate.now().plusDays(20)),
             arenaTiltak(tiltak = AMOE, status = DeltakerStatusType.TILBUD, LocalDate.now().plusDays(10), LocalDate.now().plusDays(20)),
@@ -157,7 +150,6 @@ internal class RouteServiceImplTest {
         coEvery { kometClient.hentTiltakDeltagelser(any()) } returns listOf(
             kometDeltaker("ARBFORB", DeltakerStatusDTO.DELTAR),
         )
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("ARBFORB")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             arenaTiltak(AMO, DeltakerStatusType.JATAKK),
         )
@@ -181,7 +173,6 @@ internal class RouteServiceImplTest {
         coEvery { kometClient.hentTiltakDeltagelser(any()) } returns listOf(
             kometDeltaker("VASV", DeltakerStatusDTO.DELTAR),
         )
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("VASV")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             arenaTiltak(ArenaTiltaksaktivitetResponsDTO.TiltakType.KURS, DeltakerStatusType.JATAKK),
         )
@@ -209,7 +200,6 @@ internal class RouteServiceImplTest {
             kometDeltaker("ARBFORB", DeltakerStatusDTO.VENTER_PA_OPPSTART),
             kometDeltaker("ARBFORB", DeltakerStatusDTO.HAR_SLUTTET),
         )
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("ARBFORB")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             arenaTiltak(AMO, DeltakerStatusType.DELAVB),
             arenaTiltak(AMO, DeltakerStatusType.FULLF),
@@ -243,7 +233,6 @@ internal class RouteServiceImplTest {
             kometDeltaker("ARBFORB", DeltakerStatusDTO.SOKT_INN),
             kometDeltaker("ARBFORB", DeltakerStatusDTO.VENTELISTE),
         )
-        coEvery { valpClient.hentTiltakGjennomføring(any()) } returns valpGjennomføring("ARBFORB")
         coEvery { arenaClient.hentTiltakArena(any()) } returns listOf(
             arenaTiltak(ArenaTiltaksaktivitetResponsDTO.TiltakType.AMO, DeltakerStatusType.AKTUELL),
             arenaTiltak(ArenaTiltaksaktivitetResponsDTO.TiltakType.AMO, DeltakerStatusType.AVSLAG),
@@ -284,22 +273,6 @@ private fun arenaTiltak(
         antallDagerPerUke = 2F,
     )
 }
-private fun valpGjennomføring(arenakode: String): ValpDTO {
-    return ValpDTO(
-        id = UUID.randomUUID(),
-        tiltakstype = Tiltakstype(
-            id = UUID.randomUUID(),
-            navn = "navn",
-            arenaKode = arenakode,
-        ),
-        navn = "navn",
-        startDato = LocalDate.of(2023, 1, 1),
-        sluttDato = LocalDate.of(2023, 3, 31),
-        status = Tiltaksgjennomforingsstatus.AVBRUTT,
-        virksomhetsnummer = "123",
-        oppstart = TiltaksgjennomforingOppstartstype.FELLES,
-    )
-}
 
 private fun kometDeltaker(type: String, status: DeltakerStatusDTO): DeltakerDTO {
     return DeltakerDTO(
@@ -308,6 +281,7 @@ private fun kometDeltaker(type: String, status: DeltakerStatusDTO): DeltakerDTO 
             id = "id",
             navn = "navn",
             type = type,
+            tiltakstypeNavn = "tiltakstypeNavn",
             arrangor = ArrangorDTO(virksomhetsnummer = "123", navn = "arrangor"),
         ),
         startDato = LocalDate.of(2023, 1, 1),


### PR DESCRIPTION
## Beskrivelse
Komet har lagt til et nytt felt tiltakstypeNavn slik at vi slipper å hente det fra Valp. 
Dette er det eneste feltet fra Valp vi egentlig bruker. Denne endringen slutter å kalle Valp, men bruker nå kun felter fra Komet. 

## Kommentarer
Fom og Tom fra Valp brukes egentlig ikke. Det er laget et eget Trello kort på å fjerne disse feltene fra grensesnittet ut av tiltakspenger-tiltak

## Visuelle endringer:
Ingen
