### PR TITLE
R bumper libs til nyeste versjon, retter opp i GjennomføringDTO (fjerner fom og tom) og fjerner noe utkommentert kode fra build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ val mockkVersion = "1.13.9"
 val ktorVersion = "2.3.7"
 val jacksonVersion = "2.16.1"
 val kotestVersion = "5.8.0"
+val libsVersjon = "0.0.87"
 
 plugins {
     application
@@ -28,10 +29,9 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("org.jetbrains:annotations:24.1.0")
     implementation("com.github.navikt:rapids-and-rivers:2023101613431697456627.0cdd93eb696f")
-    // implementation("com.github.navikt:rapids-and-rivers:2022112407251669271100.df879df951cf")
     implementation("com.natpryce:konfig:1.6.10.0")
-    implementation("com.github.navikt.tiltakspenger-libs:tiltak-dtos:0.0.66")
-    implementation("com.github.navikt.tiltakspenger-libs:arenatiltak-dtos:0.0.66")
+    implementation("com.github.navikt.tiltakspenger-libs:tiltak-dtos:$libsVersjon")
+    implementation("com.github.navikt.tiltakspenger-libs:arenatiltak-dtos:$libsVersjon")
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
@@ -73,11 +73,6 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.9.22")
 }
 
-/*configurations.all {
-    // exclude JUnit 4
-    exclude(group = "junit", module = "junit")
-}*/
-
 application {
     mainClass.set("no.nav.tiltakspenger.tiltak.ApplicationKt")
 }
@@ -107,16 +102,6 @@ tasks {
         // https://phauer.com/2018/best-practices-unit-testing-kotlin/
         systemProperty("junit.jupiter.testinstance.lifecycle.default", "per_class")
     }
-    /*
-    analyzeClassesDependencies {
-        warnUsedUndeclared = true
-        warnUnusedDeclared = true
-    }
-    analyzeTestClassesDependencies {
-        warnUsedUndeclared = true
-        warnUnusedDeclared = true
-    }
-     */
 }
 
 task("addPreCommitGitHookOnBuild") {

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
@@ -75,8 +75,6 @@ private fun mapKometTiltak(deltakelse: DeltakerDTO): TiltakDTO {
             arrangørnavn = deltakelse.gjennomforing.arrangor.navn,
             typeNavn = deltakelse.gjennomforing.tiltakstypeNavn,
             arenaKode = TiltakType.valueOf(deltakelse.gjennomforing.type),
-            fom = null,
-            tom = null,
         ),
         kilde = "Komet",
         deltakelseStatus = when (deltakelse.status) {
@@ -107,8 +105,6 @@ private fun mapArenaTiltak(tiltak: ArenaTiltaksaktivitetResponsDTO.Tiltaksaktivi
             arrangørnavn = tiltak.arrangoer ?: "Ukjent",
             typeNavn = tiltak.tiltakType.navn,
             arenaKode = TiltakType.valueOf(tiltak.tiltakType.name),
-            fom = null,
-            tom = null,
         ),
         deltakelseFom = earliest(tiltak.deltakelsePeriode?.fom, tiltak.deltakelsePeriode?.tom),
         deltakelseTom = latest(tiltak.deltakelsePeriode?.fom, tiltak.deltakelsePeriode?.tom),


### PR DESCRIPTION
## Beskrivelse
Bumper libs til nyeste versjon (som jeg nettopp pushet ut), retter opp i GjennomføringDTO (fjerner fom og tom) og fjerner noe utkommentert kode fra build.gradle.kts

## Kommentarer
Med denne endringen samles også versjoneringen på `arenatiltak-dtos`og `tiltak-dtos`. Jeg vet ikke hvorfor de ikke var samlet i en variabel i utgangspunktet, men om noen vet at den ene må forbli på 0.0.66, si ifra! 😄 