### PR TITLE
1119 lar være å endre på dataene vi mottar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ val mockkVersion = "1.13.16"
 val ktorVersion = "3.1.1"
 val jacksonVersion = "2.18.2"
 val kotestVersion = "5.9.1"
-val felleslibVersion = "0.0.373"
+val felleslibVersion = "0.0.378"
 
 plugins {
     application
@@ -37,6 +37,7 @@ dependencies {
     implementation("com.github.navikt.tiltakspenger-libs:tiltak-dtos:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:arenatiltak-dtos:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:common:$felleslibVersion")
+    implementation("com.github.navikt.tiltakspenger-libs:logging:$felleslibVersion")
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/Application.kt
@@ -5,16 +5,16 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.util.AttributeKey
 import mu.KotlinLogging
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
 
 fun main() {
     System.setProperty("logback.configurationFile", Configuration.logbackConfigurationFile())
 
     val log = KotlinLogging.logger {}
-    val securelog = KotlinLogging.logger("tjenestekall")
     log.info { "starting server" }
     Thread.setDefaultUncaughtExceptionHandler { _, e ->
         log.error { e }
-        securelog.error(e) { e.message }
+        sikkerlogg.error(e) { e.message }
     }
     val appBuilder = ApplicationBuilder()
 

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/DefaultObjects.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/DefaultObjects.kt
@@ -20,10 +20,10 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
 import io.ktor.serialization.jackson.JacksonConverter
 import mu.KotlinLogging
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import java.time.Duration
 
 private val LOG = KotlinLogging.logger {}
-private val SECURELOG = KotlinLogging.logger("tjenestekall")
 private const val SIXTY_SECONDS = 60L
 
 // engine skal brukes primært i test-øyemed, når man sender med MockEngine.
@@ -61,14 +61,14 @@ fun httpClientWithRetry(
                 maxRetries = 3
                 retryIf { request, response ->
                     if (response.status.value.let { it in 500..599 }) {
-                        SECURELOG.warn("Http-kall feilet med ${response.status.value}. Kjører retry")
+                        sikkerlogg.warn("Http-kall feilet med ${response.status.value}. Kjører retry")
                         true
                     } else {
                         false
                     }
                 }
                 retryOnExceptionIf { request, throwable ->
-                    SECURELOG.warn("Kastet exception ved http-kall: ${throwable.message}")
+                    sikkerlogg.warn("Kastet exception ved http-kall: ${throwable.message}")
                     true
                 }
                 constantDelay(100, 0, false)
@@ -89,7 +89,7 @@ private fun defaultSetup(objectMapper: ObjectMapper): HttpClientConfig<*>.() -> 
         logger = object : Logger {
             override fun log(message: String) {
                 LOG.info("HttpClient detaljer logget til securelog")
-                SECURELOG.info(message)
+                sikkerlogg.info(message)
             }
         }
         level = LogLevel.ALL

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/TiltakApi.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/TiltakApi.kt
@@ -20,7 +20,7 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.response.respond
 import io.ktor.server.routing.routing
-import mu.KotlinLogging
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.tiltak.routes.azureRoutes
 import no.nav.tiltakspenger.tiltak.routes.healthRoutes
 import no.nav.tiltakspenger.tiltak.routes.tokenxRoutes
@@ -53,8 +53,6 @@ fun Application.setupRouting(
 }
 
 fun Application.installAuthentication() {
-    val securelog = KotlinLogging.logger("tjenestekall")
-
     val tokenxValidationConfig = Configuration.tokenxValidationConfig()
     val azureValidationConfig = Configuration.azureValidationConfig()
 
@@ -81,11 +79,11 @@ fun Application.installAuthentication() {
         jwt("tokenx") {
             verifier(tokenxTokenProvider, tokenxValidationConfig.issuer)
             challenge { _, _ ->
-                securelog.info { "verifier feilet" }
+                sikkerlogg.info { "verifier feilet" }
                 call.respond(HttpStatusCode.Unauthorized, "Ikke tilgang! Issuer: ${tokenxValidationConfig.issuer}")
             }
             validate { credential ->
-                securelog.info("Credentials: $credential")
+                sikkerlogg.info("Credentials: $credential")
                 if (credential.audience.contains(tokenxValidationConfig.clientId) &&
                     credential.payload.getClaim("pid")
                         .asString() != ""
@@ -110,7 +108,6 @@ fun Application.jacksonSerialization() {
 }
 
 internal fun Application.installCallLogging() {
-    val securelog = KotlinLogging.logger("tjenestekall")
     install(CallId) {
         generate { UUID.randomUUID().toString() }
     }
@@ -127,9 +124,8 @@ internal fun Application.installCallLogging() {
             val httpMethod = call.request.httpMethod.value
             val req = call.request
             val userAgent = call.request.headers["User-Agent"]
-            val auth = call.request.headers["Authorization"]
-            securelog.info { "Authentication: $auth" }
-            "Status: $status, HTTP method: $httpMethod, User agent: $userAgent req: $req"
+            sikkerlogg.info { "Status: $status, HTTP method: $httpMethod, User agent: $userAgent req: $req" }
+            "Status: $status, HTTP method: $httpMethod, User agent: $userAgent"
         }
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometResponseJson.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometResponseJson.kt
@@ -1,28 +1,25 @@
 package no.nav.tiltakspenger.tiltak.clients.komet
 
-import mu.KotlinLogging
-import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.DeltakerStatusDTO
+import no.nav.tiltakspenger.libs.tiltak.KometDeltakerStatusType
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.GjennomføringDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.TiltakDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.TiltakType
 import no.nav.tiltakspenger.libs.tiltak.TiltakTilSaksbehandlingDTO
-import no.nav.tiltakspenger.tiltak.services.earliest
-import no.nav.tiltakspenger.tiltak.services.latest
+import no.nav.tiltakspenger.libs.tiltak.toDeltakerStatusDTO
 import java.time.LocalDate
 import java.time.LocalDateTime
-
-private val logger = KotlinLogging.logger { }
 
 /**
  * https://confluence.adeo.no/pages/viewpage.action?pageId=573710206
  * https://confluence.adeo.no/pages/viewpage.action?pageId=597205082
+ * Formatet er mye det samme som beskrevet her: https://github.com/navikt/amt-tiltak/blob/main/.docs/deltaker-v1.md
  */
 data class KometResponseJson(
     val id: String,
     val gjennomforing: GjennomforingDTO,
     val startDato: LocalDate?,
     val sluttDato: LocalDate?,
-    val status: String,
+    val status: KometDeltakerStatusType,
     val dagerPerUke: Float?,
     val prosentStilling: Float?,
     val registrertDato: LocalDateTime,
@@ -48,7 +45,7 @@ internal fun KometResponseJson.toSaksbehandlingDTO(): TiltakTilSaksbehandlingDTO
         deltakelseFom = startDato,
         deltakelseTom = sluttDato,
         gjennomføringId = gjennomforing.id,
-        typeNavn = gjennomforing.navn,
+        typeNavn = gjennomforing.tiltakstypeNavn,
         typeKode = TiltakType.valueOf(gjennomforing.type),
         deltakelseStatus = this.status.toDeltakerStatusDTO(),
         deltakelsePerUke = dagerPerUke,
@@ -60,8 +57,8 @@ internal fun KometResponseJson.toSaksbehandlingDTO(): TiltakTilSaksbehandlingDTO
 internal fun KometResponseJson.toSøknadTiltak(): TiltakDTO {
     return TiltakDTO(
         id = id,
-        deltakelseFom = earliest(startDato, sluttDato),
-        deltakelseTom = latest(startDato, sluttDato),
+        deltakelseFom = startDato,
+        deltakelseTom = sluttDato,
         deltakelseDagerUke = dagerPerUke,
         deltakelseProsent = prosentStilling,
         registrertDato = registrertDato,
@@ -74,28 +71,4 @@ internal fun KometResponseJson.toSøknadTiltak(): TiltakDTO {
         kilde = "Komet",
         deltakelseStatus = this.status.toDeltakerStatusDTO(),
     )
-}
-
-private fun String.toDeltakerStatusDTO() = when (this) {
-    "AVBRUTT" -> DeltakerStatusDTO.AVBRUTT
-    "FULLFORT" -> DeltakerStatusDTO.FULLFORT
-    "DELTAR" -> DeltakerStatusDTO.DELTAR
-    "IKKE_AKTUELL" -> DeltakerStatusDTO.IKKE_AKTUELL
-    "VENTER_PA_OPPSTART" -> DeltakerStatusDTO.VENTER_PA_OPPSTART
-    "HAR_SLUTTET" -> DeltakerStatusDTO.HAR_SLUTTET
-
-    // Disse er ikke med i søknaden
-    "VURDERES" -> DeltakerStatusDTO.VURDERES
-    "FEILREGISTRERT" -> DeltakerStatusDTO.FEILREGISTRERT
-    "PABEGYNT_REGISTRERING" -> DeltakerStatusDTO.PABEGYNT_REGISTRERING
-    "SOKT_INN" -> DeltakerStatusDTO.SOKT_INN
-    "VENTELISTE" -> DeltakerStatusDTO.VENTELISTE
-    /** Mappes til AKTUELL i Arena */
-    "UTKAST_TIL_PAMELDING" -> DeltakerStatusDTO.PABEGYNT_REGISTRERING
-    /** Mappes til IKKAKTUELL i Arena */
-    "AVBRUTT_UTKAST" -> DeltakerStatusDTO.IKKE_AKTUELL
-    else -> {
-        logger.error { "Ukjent deltakerstatus fra Komet: $this. Denne bør legges til ASAP." }
-        throw RuntimeException("Klarte ikke tolke respons fra Komet. Ukjent deltakerstatus: $this")
-    }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/routes/AzureRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/routes/AzureRoutes.kt
@@ -1,7 +1,6 @@
 package no.nav.tiltakspenger.tiltak.routes
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
@@ -9,14 +8,12 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import mu.KotlinLogging
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.tiltak.services.RoutesService
 
 fun Route.azureRoutes(
     routesService: RoutesService,
 ) {
-    val securelog = KotlinLogging.logger("tjenestekall")
-
     data class RequestBody(
         val ident: String,
     )
@@ -26,7 +23,7 @@ fun Route.azureRoutes(
         val correlationId = call.request.headers["Nav-Call-Id"]
         val response = routesService.hentTiltakForSaksbehandling(ident, correlationId)
 
-        securelog.info { response }
+        sikkerlogg.info { response }
         call.respond(message = response, status = HttpStatusCode.OK)
     }
 
@@ -35,7 +32,7 @@ fun Route.azureRoutes(
         val correlationId = call.request.headers["Nav-Call-Id"]
 
         val response = routesService.hentTiltakForSaksbehandling(ident, correlationId)
-        securelog.info { response }
+        sikkerlogg.info { response }
         call.respond(message = response, status = HttpStatusCode.OK)
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/routes/TokenxRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/routes/TokenxRoutes.kt
@@ -1,7 +1,6 @@
 package no.nav.tiltakspenger.tiltak.routes
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
@@ -9,8 +8,8 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.tiltak.services.RoutesService
 
 data class RequestBody(
@@ -20,15 +19,13 @@ data class RequestBody(
 fun Route.tokenxRoutes(
     routesService: RoutesService,
 ) {
-    val securelog = KotlinLogging.logger("tjenestekall")
-
     get("/tokenx/tiltak") {
         val ident = requireNotNull(call.principal<JWTPrincipal>()?.getClaim("pid", String::class)) { "pid er null i token" }
         // Genereres her foreløpig til den legges ved i kallet fra soknad-api
         val correlationId = CorrelationId.generate()
         val response = routesService.hentTiltakForSøknad(ident, correlationId.value)
 
-        securelog.info { response }
+        sikkerlogg.info { response }
         call.respond(message = response, status = HttpStatusCode.OK)
     }
 
@@ -37,7 +34,7 @@ fun Route.tokenxRoutes(
         // Genereres her foreløpig til den legges ved i kallet fra soknad-api
         val correlationId = CorrelationId.generate()
         val response = routesService.hentTiltakForSøknad(ident, correlationId.value)
-        securelog.info { response }
+        sikkerlogg.info { response }
         call.respond(message = response, status = HttpStatusCode.OK)
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImpl.kt
@@ -1,15 +1,13 @@
 package no.nav.tiltakspenger.tiltak.services
 
 import kotlinx.coroutines.runBlocking
-import mu.KotlinLogging
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.TiltakDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakTilSaksbehandlingDTO
 import no.nav.tiltakspenger.tiltak.clients.arena.ArenaClient
 import no.nav.tiltakspenger.tiltak.clients.komet.KometClient
 import no.nav.tiltakspenger.tiltak.clients.komet.toSaksbehandlingDTO
 import no.nav.tiltakspenger.tiltak.clients.komet.toSøknadTiltak
-
-val securelog = KotlinLogging.logger("tjenestekall")
 
 class RouteServiceImpl(
     private val kometClient: KometClient,
@@ -25,7 +23,7 @@ class RouteServiceImpl(
             val arena = arenaClient.hentTiltakArena(fnr, correlationId)
                 .filterNot { it.tiltakType.name in tiltakViFårFraKomet }
                 .map {
-                    securelog.info { "Deltakelsene fra Arena vi mapper tilbake $it" }
+                    sikkerlogg.info { "Deltakelsene fra Arena vi mapper tilbake $it" }
                     it.toSaksbehandlingDTO()
                 }
             arena + komet
@@ -44,7 +42,7 @@ class RouteServiceImpl(
             val arena = arenaClient.hentTiltakArena(fnr, correlationId)
                 .filterNot { it.tiltakType.name in tiltakViFårFraKomet }
                 .map {
-                    securelog.info { "Deltakelsene fra Arena vi mapper tilbake $it" }
+                    sikkerlogg.info { "Deltakelsene fra Arena vi mapper tilbake $it" }
                     it.toSøknadTiltak()
                 }
             arena + komet

--- a/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/TiltakMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/tiltak/services/TiltakMapper.kt
@@ -1,27 +1,23 @@
 package no.nav.tiltakspenger.tiltak.services
 
-import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.DeltakelsesPeriodeDTO
-import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.DeltakerStatusType
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltaksaktivitetDTO
-import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.DeltakerStatusDTO
+import no.nav.tiltakspenger.libs.arena.tiltak.toDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.GjennomføringDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.TiltakDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.TiltakType
 import no.nav.tiltakspenger.libs.tiltak.TiltakTilSaksbehandlingDTO
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 // Vi får ikke gjennomføringId fra Arena
 // confluenseside for endepunktet vi kaller for å hente Arenatiltak: https://confluence.adeo.no/pages/viewpage.action?pageId=470748287
 internal fun TiltaksaktivitetDTO.toSaksbehandlingDTO(): TiltakTilSaksbehandlingDTO = TiltakTilSaksbehandlingDTO(
-    // TODO pre-mvp jah: Dette er tiltaksdeltakerId, jeg er litt usikker på om det er riktig nok at denne mappes til id.
     id = aktivitetId,
     gjennomføringId = null,
-    deltakelseFom = earliest(deltakelsePeriode?.fom, deltakelsePeriode?.tom),
-    deltakelseTom = latest(deltakelsePeriode?.fom, deltakelsePeriode?.tom),
+    deltakelseFom = deltakelsePeriode?.fom,
+    deltakelseTom = deltakelsePeriode?.tom,
     typeNavn = tiltakType.navn,
     typeKode = TiltakType.valueOf(tiltakType.name),
-    deltakelseStatus = deltakerStatusType.toDTO(deltakelsePeriode),
+    deltakelseStatus = deltakerStatusType.toDTO(deltakelsePeriode?.fom),
     deltakelsePerUke = antallDagerPerUke,
     deltakelseProsent = deltakelseProsent,
     kilde = "Arena",
@@ -36,58 +32,14 @@ internal fun TiltaksaktivitetDTO.toSøknadTiltak(): TiltakDTO =
             typeNavn = tiltakType.navn,
             arenaKode = TiltakType.valueOf(tiltakType.name),
         ),
-        deltakelseFom = earliest(deltakelsePeriode?.fom, deltakelsePeriode?.tom),
-        deltakelseTom = latest(deltakelsePeriode?.fom, deltakelsePeriode?.tom),
-        deltakelseStatus = deltakerStatusType.toDTO(deltakelsePeriode),
+        deltakelseFom = deltakelsePeriode?.fom,
+        deltakelseTom = deltakelsePeriode?.tom,
+        deltakelseStatus = deltakerStatusType.toDTO(deltakelsePeriode?.fom),
         deltakelseDagerUke = antallDagerPerUke,
         deltakelseProsent = deltakelseProsent,
         kilde = "Arena",
         registrertDato = statusSistEndret?.let { LocalDateTime.from(it.atStartOfDay()) } ?: LocalDateTime.now(),
     )
-
-// Fordi Arena noen ganger bytter om på fom og tom, må vi bytte tilbake hvis det skjer...
-internal fun earliest(fom: LocalDate?, tom: LocalDate?) =
-    when {
-        fom != null && tom != null -> if (tom.isBefore(fom)) {
-            securelog.warn { "fom er etter tom, så vi bytter om de to datoene på tiltaket" }
-            tom
-        } else {
-            fom
-        }
-
-        else -> fom
-    }
-
-internal fun latest(fom: LocalDate?, tom: LocalDate?) =
-    when {
-        fom != null && tom != null -> if (fom.isAfter(tom)) fom else tom
-        else -> tom
-    }
-
-fun DeltakerStatusType.toDTO(deltakelsePeriode: DeltakelsesPeriodeDTO?): DeltakerStatusDTO {
-    val fom = earliest(deltakelsePeriode?.fom, deltakelsePeriode?.tom) ?: LocalDate.MAX
-    val startDatoErFremITid = (fom.isAfter(LocalDate.now()))
-
-    return when (this) {
-        DeltakerStatusType.DELAVB -> DeltakerStatusDTO.AVBRUTT
-        DeltakerStatusType.FULLF -> DeltakerStatusDTO.FULLFORT
-        DeltakerStatusType.GJENN -> if (startDatoErFremITid) DeltakerStatusDTO.VENTER_PA_OPPSTART else DeltakerStatusDTO.DELTAR
-        DeltakerStatusType.GJENN_AVB -> DeltakerStatusDTO.AVBRUTT
-        DeltakerStatusType.IKKEM -> DeltakerStatusDTO.AVBRUTT
-        DeltakerStatusType.JATAKK -> DeltakerStatusDTO.DELTAR
-        DeltakerStatusType.TILBUD -> if (startDatoErFremITid) DeltakerStatusDTO.VENTER_PA_OPPSTART else DeltakerStatusDTO.DELTAR
-
-        // Disse er ikke med i søknaden
-        DeltakerStatusType.AKTUELL -> DeltakerStatusDTO.SOKT_INN
-        DeltakerStatusType.AVSLAG -> DeltakerStatusDTO.IKKE_AKTUELL
-        DeltakerStatusType.GJENN_AVL -> DeltakerStatusDTO.IKKE_AKTUELL
-        DeltakerStatusType.IKKAKTUELL -> DeltakerStatusDTO.IKKE_AKTUELL
-        DeltakerStatusType.INFOMOETE -> DeltakerStatusDTO.VENTELISTE
-        DeltakerStatusType.NEITAKK -> DeltakerStatusDTO.IKKE_AKTUELL
-        DeltakerStatusType.VENTELISTE -> DeltakerStatusDTO.VENTELISTE
-        DeltakerStatusType.FEILREG -> DeltakerStatusDTO.FEILREGISTRERT
-    }
-}
 
 val tiltakViFårFraKomet = setOf(
     "INDOPPFAG",

--- a/src/test/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometClientImplTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/tiltak/clients/komet/KometClientImplTest.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
+import no.nav.tiltakspenger.libs.tiltak.KometDeltakerStatusType
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
@@ -45,7 +46,7 @@ internal class KometClientImplTest {
                     id = "1c51c943-ce2d-4029-8c1e-18b3c59d3e2e",
                     startDato = null,
                     sluttDato = null,
-                    status = "IKKE_AKTUELL",
+                    status = KometDeltakerStatusType.IKKE_AKTUELL,
                     dagerPerUke = 2.0F,
                     prosentStilling = 100.0F,
                     registrertDato = LocalDateTime.of(2022, 2, 17, 14, 53, 31),

--- a/src/test/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImplTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/tiltak/services/RouteServiceImplTest.kt
@@ -4,15 +4,17 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
+import no.nav.tiltakspenger.libs.arena.tiltak.ArenaDeltakerStatusType
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO
-import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.DeltakerStatusType
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.AMO
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.AMOB
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.AMOE
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.AMOY
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.ARBTREN
+import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.HOYEREUTD
 import no.nav.tiltakspenger.libs.arena.tiltak.ArenaTiltaksaktivitetResponsDTO.TiltakType.KURS
+import no.nav.tiltakspenger.libs.tiltak.KometDeltakerStatusType
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.DeltakerStatusDTO.DELTAR
 import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.DeltakerStatusDTO.FEILREGISTRERT
@@ -41,10 +43,10 @@ internal class RouteServiceImplTest {
         )
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns listOf(
-            kometDeltaker("VASV", "AVBRUTT"),
+            kometDeltaker("VASV", KometDeltakerStatusType.AVBRUTT),
         )
         coEvery { arenaClient.hentTiltakArena(any(), any()) } returns listOf(
-            arenaTiltak(KURS, DeltakerStatusType.DELAVB),
+            arenaTiltak(KURS, ArenaDeltakerStatusType.DELAVB),
         )
 
         val tiltakListe = routesService.hentTiltakForSøknad("123", "correlationId")
@@ -61,37 +63,37 @@ internal class RouteServiceImplTest {
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns listOf(
             // Disse skal være med...
-            kometDeltaker("ARBFORB", "AVBRUTT"),
-            kometDeltaker("ARBFORB", "FULLFORT"),
-            kometDeltaker("ARBFORB", "DELTAR"),
-            kometDeltaker("ARBFORB", "VENTER_PA_OPPSTART"),
-            kometDeltaker("ARBFORB", "HAR_SLUTTET"),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.AVBRUTT),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.FULLFORT),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.DELTAR),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.VENTER_PA_OPPSTART),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.HAR_SLUTTET),
             // Disse skal ikke være med
-            kometDeltaker("ARBFORB", "IKKE_AKTUELL"),
-            kometDeltaker("ARBFORB", "VURDERES"),
-            kometDeltaker("ARBFORB", "FEILREGISTRERT"),
-            kometDeltaker("ARBFORB", "PABEGYNT_REGISTRERING"),
-            kometDeltaker("ARBFORB", "SOKT_INN"),
-            kometDeltaker("ARBFORB", "VENTELISTE"),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.IKKE_AKTUELL),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.VURDERES),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.FEILREGISTRERT),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.PABEGYNT_REGISTRERING),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.SOKT_INN),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.VENTELISTE),
         )
         coEvery { arenaClient.hentTiltakArena(any(), any()) } returns listOf(
             // Disse skal være med
-            arenaTiltak(ARBTREN, DeltakerStatusType.DELAVB),
-            arenaTiltak(ARBTREN, DeltakerStatusType.FULLF),
-            arenaTiltak(ARBTREN, DeltakerStatusType.GJENN),
-            arenaTiltak(ARBTREN, DeltakerStatusType.GJENN_AVB),
-            arenaTiltak(ARBTREN, DeltakerStatusType.IKKEM),
-            arenaTiltak(ARBTREN, DeltakerStatusType.JATAKK),
-            arenaTiltak(ARBTREN, DeltakerStatusType.TILBUD),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.DELAVB),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.FULLF),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.GJENN),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.GJENN_AVB),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.IKKEM),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.JATAKK),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.TILBUD),
 
             // Disse skal ikke være med
-            arenaTiltak(ARBTREN, DeltakerStatusType.AKTUELL),
-            arenaTiltak(ARBTREN, DeltakerStatusType.AVSLAG),
-            arenaTiltak(ARBTREN, DeltakerStatusType.GJENN_AVL),
-            arenaTiltak(ARBTREN, DeltakerStatusType.IKKAKTUELL),
-            arenaTiltak(ARBTREN, DeltakerStatusType.INFOMOETE),
-            arenaTiltak(ARBTREN, DeltakerStatusType.NEITAKK),
-            arenaTiltak(ARBTREN, DeltakerStatusType.VENTELISTE),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.AKTUELL),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.AVSLAG),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.GJENN_AVL),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.IKKAKTUELL),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.INFOMOETE),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.NEITAKK),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.VENTELISTE),
         )
 
         val tiltakListe = routesService.hentTiltakForSøknad("123", "correlationId")
@@ -119,26 +121,26 @@ internal class RouteServiceImplTest {
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns emptyList()
         val arenaTiltak1 = arenaTiltak(
-            tiltak = AMO,
-            status = DeltakerStatusType.GJENN,
+            tiltak = HOYEREUTD,
+            status = ArenaDeltakerStatusType.GJENN,
             LocalDate.now().plusDays(10),
             LocalDate.now().plusDays(20),
         )
         val arenaTiltak2 = arenaTiltak(
             tiltak = AMOE,
-            status = DeltakerStatusType.TILBUD,
+            status = ArenaDeltakerStatusType.TILBUD,
             LocalDate.now().plusDays(10),
             LocalDate.now().plusDays(20),
         )
         val arenaTiltak3 = arenaTiltak(
             tiltak = AMOB,
-            status = DeltakerStatusType.GJENN,
+            status = ArenaDeltakerStatusType.GJENN,
             LocalDate.now().minusDays(20),
             LocalDate.now().minusDays(10),
         )
         val arenaTiltak4 = arenaTiltak(
             tiltak = AMOY,
-            status = DeltakerStatusType.TILBUD,
+            status = ArenaDeltakerStatusType.TILBUD,
             LocalDate.now().minusDays(20),
             LocalDate.now().minusDays(10),
         )
@@ -157,9 +159,9 @@ internal class RouteServiceImplTest {
         }
 
         routesService.hentTiltakForSøknad("123", "correlationId").also { actual ->
-            // Vi filtrer ut AMO, AMOE;AMOB,AMOY
-            // TODO post-mvp jah: Kanskje vi burde bruke noen tiltak i denne testen som ikke filtreres ut?
-            actual.size shouldBe 0
+            // Vi filtrer ut AMOE,AMOB,AMOY
+            actual.size shouldBe 1
+            actual[0].deltakelseStatus shouldBe VENTER_PA_OPPSTART
         }
     }
 
@@ -171,10 +173,10 @@ internal class RouteServiceImplTest {
         )
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns listOf(
-            kometDeltaker("ARBFORB", "DELTAR"),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.DELTAR),
         )
         coEvery { arenaClient.hentTiltakArena(any(), any()) } returns listOf(
-            arenaTiltak(ARBTREN, DeltakerStatusType.JATAKK),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.JATAKK),
         )
         routesService.hentTiltakForSaksbehandling("123", "correlationId").also {
             it.size shouldBe 2
@@ -196,10 +198,10 @@ internal class RouteServiceImplTest {
         )
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns listOf(
-            kometDeltaker("VASV", "DELTAR"),
+            kometDeltaker("VASV", KometDeltakerStatusType.DELTAR),
         )
         coEvery { arenaClient.hentTiltakArena(any(), any()) } returns listOf(
-            arenaTiltak(KURS, DeltakerStatusType.JATAKK),
+            arenaTiltak(KURS, ArenaDeltakerStatusType.JATAKK),
         )
 
         routesService.hentTiltakForSaksbehandling("123", "correlationId").also {
@@ -221,30 +223,32 @@ internal class RouteServiceImplTest {
         )
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns listOf(
-            kometDeltaker("ARBFORB", "AVBRUTT"),
-            kometDeltaker("ARBFORB", "FULLFORT"),
-            kometDeltaker("ARBFORB", "DELTAR"),
-            kometDeltaker("ARBFORB", "VENTER_PA_OPPSTART"),
-            kometDeltaker("ARBFORB", "HAR_SLUTTET"),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.AVBRUTT),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.FULLFORT),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.DELTAR),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.VENTER_PA_OPPSTART),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.HAR_SLUTTET),
         )
         coEvery { arenaClient.hentTiltakArena(any(), any()) } returns listOf(
-            arenaTiltak(AMO, DeltakerStatusType.DELAVB),
-            arenaTiltak(AMO, DeltakerStatusType.FULLF),
-            arenaTiltak(AMO, DeltakerStatusType.GJENN),
-            arenaTiltak(AMO, DeltakerStatusType.GJENN_AVB),
-            arenaTiltak(AMO, DeltakerStatusType.IKKEM),
-            arenaTiltak(AMO, DeltakerStatusType.JATAKK),
-            arenaTiltak(AMO, DeltakerStatusType.TILBUD),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.DELAVB),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.FULLF),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.GJENN),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.GJENN_AVB),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.IKKEM),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.JATAKK),
+            arenaTiltak(ARBTREN, ArenaDeltakerStatusType.TILBUD),
         )
 
         routesService.hentTiltakForSaksbehandling("123", "correlationId").also {
             it.size shouldBe 12
             it.all { it.deltakelseStatus.rettTilÅSøke }
+            it.all { it.typeKode.rettPåTiltakspenger }
         }
 
         routesService.hentTiltakForSøknad("123", "correlationId").also {
-            // TODO post-mvp jah: Her bør vi kanskje også bruke typer som faktisk gir rett til å søke?
-            it.size shouldBe 5
+            it.size shouldBe 12
+            it.all { it.deltakelseStatus.rettTilÅSøke }
+            it.all { it.gjennomforing.arenaKode.rettPåTiltakspenger }
         }
     }
 
@@ -256,21 +260,21 @@ internal class RouteServiceImplTest {
         )
 
         coEvery { kometClient.hentTiltakDeltagelser(any(), any()) } returns listOf(
-            kometDeltaker("ARBFORB", "IKKE_AKTUELL"),
-            kometDeltaker("ARBFORB", "VURDERES"),
-            kometDeltaker("ARBFORB", "FEILREGISTRERT"),
-            kometDeltaker("ARBFORB", "PABEGYNT_REGISTRERING"),
-            kometDeltaker("ARBFORB", "SOKT_INN"),
-            kometDeltaker("ARBFORB", "VENTELISTE"),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.IKKE_AKTUELL),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.VURDERES),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.FEILREGISTRERT),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.PABEGYNT_REGISTRERING),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.SOKT_INN),
+            kometDeltaker("ARBFORB", KometDeltakerStatusType.VENTELISTE),
         )
         coEvery { arenaClient.hentTiltakArena(any(), any()) } returns listOf(
-            arenaTiltak(AMO, DeltakerStatusType.AKTUELL),
-            arenaTiltak(AMO, DeltakerStatusType.AVSLAG),
-            arenaTiltak(AMO, DeltakerStatusType.GJENN_AVL),
-            arenaTiltak(AMO, DeltakerStatusType.IKKAKTUELL),
-            arenaTiltak(AMO, DeltakerStatusType.INFOMOETE),
-            arenaTiltak(AMO, DeltakerStatusType.NEITAKK),
-            arenaTiltak(AMO, DeltakerStatusType.VENTELISTE),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.AKTUELL),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.AVSLAG),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.GJENN_AVL),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.IKKAKTUELL),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.INFOMOETE),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.NEITAKK),
+            arenaTiltak(AMO, ArenaDeltakerStatusType.VENTELISTE),
         )
 
         routesService.hentTiltakForSaksbehandling("123", "correlationId").also {
@@ -285,7 +289,7 @@ internal class RouteServiceImplTest {
 
 private fun arenaTiltak(
     tiltak: TiltakType,
-    status: DeltakerStatusType,
+    status: ArenaDeltakerStatusType,
     fom: LocalDate = LocalDate.of(2023, 1, 1),
     tom: LocalDate = LocalDate.of(2023, 3, 31),
 ): ArenaTiltaksaktivitetResponsDTO.TiltaksaktivitetDTO {
@@ -307,7 +311,7 @@ private fun arenaTiltak(
     )
 }
 
-private fun kometDeltaker(type: String, status: String): KometResponseJson {
+private fun kometDeltaker(type: String, status: KometDeltakerStatusType): KometResponseJson {
     return KometResponseJson(
         id = "id",
         gjennomforing = KometResponseJson.GjennomforingDTO(


### PR DESCRIPTION
## Beskrivelse
Vi ønsker i minst mulig grad å endre på dataene vi mottar fra registersystemene. Endringer: 
- tatt i bruk statusmapping fra libs
- tatt i bruk sikkerlogg fra libs
- lar være å logge auth-header
- fjerner manipulasjon av start/sluttdato hvis disse kommer i feil rekkefølge
- endrer slik at vi bruker tiltakstypenavnet og ikke gjennomføringsnavnet når vi henter deltakelser fra Komet, da blir det likt som når vi henter fra Arena og funksjonelt mer riktig (avklart med Taulant)

## Kommentarer
https://trello.com/c/xIpArfVl/1119-hvordan-filtrere-mutere-tiltaksdeltagelser-fra-registere